### PR TITLE
Update image URL and fix pet status display

### DIFF
--- a/src/components/Layout/TopBar.tsx
+++ b/src/components/Layout/TopBar.tsx
@@ -124,7 +124,7 @@ export const TopBar: React.FC = () => {
               whileTap={{ scale: 0.95 }}
             >
               <img
-                src="https://cdn.builder.io/api/v1/image/assets%2Ff481900009a94cda953c032479392a30%2F8bb45b10e920461dae796f0f945a1b33?format=webp&width=800"
+                src="https://cdn.builder.io/api/v1/image/assets%2Fc30afbb5d9ef451b8b61af828c843451%2Fcc2df505223546958ac8cd396cf7ecd8?format=webp&width=800"
                 alt="Xenocash"
                 className="w-6 h-6"
               />

--- a/src/components/Pet/PetPortrait.tsx
+++ b/src/components/Pet/PetPortrait.tsx
@@ -55,7 +55,7 @@ export const PetPortrait: React.FC<PetPortraitProps> = ({ pet }) => {
       case "blessed":
         return "✨";
       case "sick":
-        return "🤒";
+        return "��";
       case "cold":
         return "🥶";
       case "hot":
@@ -89,7 +89,6 @@ export const PetPortrait: React.FC<PetPortraitProps> = ({ pet }) => {
           {pet.name}
         </motion.h2>
         <div className="flex items-center justify-center space-x-2">
-          <span className="text-2xl">{getSpeciesEmoji(pet.species)}</span>
           <p className="text-gray-600 font-medium">{pet.species}</p>
           <div className="px-2 py-1 bg-purple-100 text-purple-700 rounded-full text-xs font-medium">
             {pet.style}


### PR DESCRIPTION
Updates the TopBar component image source URL to use a new asset ID.

Modifies the PetPortrait component:
- Changes the sick status emoji from 🤒 to ��
- Removes the species emoji display from the pet information section

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a2a4183b43fe4f13b7ce1c31a65529f6/mystic-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a2a4183b43fe4f13b7ce1c31a65529f6</projectId>-->
<!--<branchName>mystic-haven</branchName>-->