### PR TITLE
Fix ship rotation logic in GalaxyMap drag handler

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -192,9 +192,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     setIsDragging(false);
     // Keep current rotation - ship maintains the direction it was moving
 
-    // Save current map position
+    // Save current map position and ship rotation
     const mapPos = { x: mapX.get(), y: mapY.get() };
     localStorage.setItem("xenopets-map-position", JSON.stringify(mapPos));
+    localStorage.setItem(
+      "xenopets-ship-rotation",
+      shipRotation.get().toString(),
+    );
   };
 
   const handlePointClick = (pointId: string) => {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -162,15 +162,22 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       const deltaX = info.delta.x;
       const deltaY = info.delta.y;
 
-      // Calculate ship rotation based on movement direction
-      // Ship should point in the direction it's moving
-      // When dragging up (deltaY negative), ship points up
-      // When dragging right (deltaX positive), ship points right, etc.
-      // Note: We negate deltaY because in screen coordinates, positive Y is down
-      // Negate deltaX to fix left/right inversion
-      // Add 90 degrees to correct the orientation (ship image seems to be rotated)
-      const angle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
-      animate(shipRotation, angle, { duration: 0.2 });
+      // Only calculate rotation if there's significant movement
+      // This prevents erratic rotation when mouse is held but not moving
+      const movementThreshold = 2;
+      const movementMagnitude = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+
+      if (movementMagnitude > movementThreshold) {
+        // Calculate ship rotation based on movement direction
+        // Ship should point in the direction it's moving
+        // When dragging up (deltaY negative), ship points up
+        // When dragging right (deltaX positive), ship points right, etc.
+        // Note: We negate deltaY because in screen coordinates, positive Y is down
+        // Negate deltaX to fix left/right inversion
+        // Add 90 degrees to correct the orientation (ship image seems to be rotated)
+        const angle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
+        animate(shipRotation, angle, { duration: 0.2 });
+      }
 
       // Update map position
       mapX.set(mapX.get() + deltaX);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -136,11 +136,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     checkProximity();
   }, [checkProximity]);
 
-  // Save position continuously and on unmount
+  // Save position and rotation continuously and on unmount
   useEffect(() => {
     const savePosition = () => {
       const mapPos = { x: mapX.get(), y: mapY.get() };
       localStorage.setItem("xenopets-map-position", JSON.stringify(mapPos));
+      localStorage.setItem(
+        "xenopets-ship-rotation",
+        shipRotation.get().toString(),
+      );
     };
 
     // Save position every 2 seconds when not dragging
@@ -155,7 +159,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       clearInterval(interval);
       savePosition();
     };
-  }, [mapX, mapY, isDragging]);
+  }, [mapX, mapY, shipRotation, isDragging]);
 
   const handleDragStart = () => {
     setIsDragging(true);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -193,15 +193,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
 
   const handleDragEnd = () => {
     setIsDragging(false);
-    // Keep current rotation - ship maintains the direction it was moving
+    // Return ship to neutral position (0 degrees) when stopped
+    animate(shipRotation, 0, { duration: 0.5 });
 
-    // Save current map position and ship rotation
+    // Save current map position and reset ship rotation to neutral
     const mapPos = { x: mapX.get(), y: mapY.get() };
     localStorage.setItem("xenopets-map-position", JSON.stringify(mapPos));
-    localStorage.setItem(
-      "xenopets-ship-rotation",
-      shipRotation.get().toString(),
-    );
+    localStorage.setItem("xenopets-ship-rotation", "0");
   };
 
   const handlePointClick = (pointId: string) => {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -103,7 +103,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
 
   const mapX = useMotionValue(savedMapPosition.current().x);
   const mapY = useMotionValue(savedMapPosition.current().y);
-  const shipRotation = useMotionValue(0); // Always start neutral
+  const shipRotation = useMotionValue(0); // Start pointing right (neutral)
 
   // Check proximity to points
   const checkProximity = useCallback(() => {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -161,15 +161,16 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     };
   }, [mapX, mapY, shipRotation, isDragging]);
 
-  const handleDragStart = () => {
-    setIsDragging(true);
+  const handleDragEnd = () => {
+    setIsDragging(false);
+    // Return ship to neutral position (0 degrees) when stopped
+    animate(shipRotation, 0, { duration: 0.5 });
+
+    // Save current map position and reset ship rotation to neutral
+    const mapPos = { x: mapX.get(), y: mapY.get() };
+    localStorage.setItem("xenopets-map-position", JSON.stringify(mapPos));
+    localStorage.setItem("xenopets-ship-rotation", "0");
   };
-
-  const handleDrag = useCallback(
-    (event: any, info: any) => {
-      if (!containerRef.current) return;
-
-      const containerRect = containerRef.current.getBoundingClientRect();
       const deltaX = info.delta.x;
       const deltaY = info.delta.y;
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -178,8 +178,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       // When dragging up (deltaY negative), ship points up
       // When dragging right (deltaX positive), ship points right, etc.
       // Note: We negate deltaY because in screen coordinates, positive Y is down
+      // Negate deltaX to fix left/right inversion
       // Add 90 degrees to correct the orientation (ship image seems to be rotated)
-      const angle = Math.atan2(-deltaY, deltaX) * (180 / Math.PI) + 90;
+      const angle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
       animate(shipRotation, angle, { duration: 0.2 });
 
       // Update map position

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -181,8 +181,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
 
   const handleDragEnd = () => {
     setIsDragging(false);
-    // Return ship to neutral position (0 degrees) when stopped
-    animate(shipRotation, 0, { duration: 0.5 });
+    // Keep current rotation - ship maintains the direction it was moving
 
     // Save current map position
     const mapPos = { x: mapX.get(), y: mapY.get() };

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -178,7 +178,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       // When dragging up (deltaY negative), ship points up
       // When dragging right (deltaX positive), ship points right, etc.
       // Note: We negate deltaY because in screen coordinates, positive Y is down
-      const angle = Math.atan2(-deltaY, deltaX) * (180 / Math.PI);
+      // Add 90 degrees to correct the orientation (ship image seems to be rotated)
+      const angle = Math.atan2(-deltaY, deltaX) * (180 / Math.PI) + 90;
       animate(shipRotation, angle, { duration: 0.2 });
 
       // Update map position

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -164,10 +164,11 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       const deltaY = info.delta.y;
 
       // Calculate ship rotation based on movement direction
-      // Ship should point OPPOSITE to drag direction (like pushing the map)
-      // When dragging up, ship points down; when dragging right, ship points left, etc.
-      // Invert both deltaX and deltaY to get opposite direction
-      const angle = Math.atan2(deltaY, -deltaX) * (180 / Math.PI) + 90;
+      // Ship should point in the direction it's moving
+      // When dragging up (deltaY negative), ship points up
+      // When dragging right (deltaX positive), ship points right, etc.
+      // Note: We negate deltaY because in screen coordinates, positive Y is down
+      const angle = Math.atan2(-deltaY, deltaX) * (180 / Math.PI);
       animate(shipRotation, angle, { duration: 0.2 });
 
       // Update map position

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -101,9 +101,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     return saved ? JSON.parse(saved) : { x: 0, y: 0 };
   });
 
+  // Load saved ship rotation
+  const savedShipRotation = useRef(() => {
+    const saved = localStorage.getItem("xenopets-ship-rotation");
+    return saved ? parseFloat(saved) : 0;
+  });
+
   const mapX = useMotionValue(savedMapPosition.current().x);
   const mapY = useMotionValue(savedMapPosition.current().y);
-  const shipRotation = useMotionValue(0); // Start pointing right (neutral)
+  const shipRotation = useMotionValue(savedShipRotation.current()); // Start with saved rotation
 
   // Check proximity to points
   const checkProximity = useCallback(() => {


### PR DESCRIPTION
Improves ship rotation behavior during map dragging:

- Add movement threshold to prevent erratic rotation when mouse is held but not moving
- Fix ship rotation direction to point in movement direction instead of opposite
- Update angle calculation by negating both deltaX and deltaY coordinates
- Add detailed comments explaining the coordinate system and rotation logic

The ship now rotates smoothly only when there's significant movement (threshold > 2 pixels) and points in the correct direction relative to the drag motion.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c252e21579a4df48ed3557321cd3383/aura-sanctuary)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c252e21579a4df48ed3557321cd3383</projectId>-->
<!--<branchName>aura-sanctuary</branchName>-->