### PR TITLE
Improve galaxy map dragging UX and move CSS to global

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -205,7 +205,10 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   return (
     <div
       ref={containerRef}
-      className="relative w-full h-[500px] bg-gradient-to-br from-gray-950 via-slate-900 to-black rounded-2xl overflow-hidden cursor-grab active:cursor-grabbing"
+      className={`relative w-full h-[500px] bg-gradient-to-br from-gray-950 via-slate-900 to-black rounded-2xl overflow-hidden ${
+        isDragging ? "cursor-grabbing" : "cursor-grab"
+      }`}
+      style={{ userSelect: "none" }}
     >
       {/* Stars background */}
       <div

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -222,24 +222,6 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
         ))}
       </div>
 
-      {/* Custom CSS for subtle star twinkling */}
-      <style jsx>{`
-        @keyframes twinkle {
-          0% {
-            opacity: 0.3;
-            transform: scale(0.8);
-          }
-          50% {
-            opacity: 0.8;
-            transform: scale(1);
-          }
-          100% {
-            opacity: 0.4;
-            transform: scale(0.9);
-          }
-        }
-      `}</style>
-
       {/* Galaxy background nebulae */}
       <div className="absolute inset-0">
         <div

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -208,7 +208,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       className="relative w-full h-[500px] bg-gradient-to-br from-gray-950 via-slate-900 to-black rounded-2xl overflow-hidden cursor-grab active:cursor-grabbing"
     >
       {/* Stars background */}
-      <div className="absolute inset-0 opacity-80">
+      <div
+        className={`absolute inset-0 opacity-80 ${isDragging ? "pointer-events-none" : ""}`}
+      >
         {stars.map((star) => (
           <div
             key={star.id}
@@ -223,7 +225,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       </div>
 
       {/* Galaxy background nebulae */}
-      <div className="absolute inset-0">
+      <div
+        className={`absolute inset-0 ${isDragging ? "pointer-events-none" : ""}`}
+      >
         <div
           className="absolute w-64 h-64 rounded-full opacity-10 blur-3xl"
           style={{

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -267,6 +267,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
             point={point}
             isNearby={nearbyPoint === point.id}
             onClick={() => handlePointClick(point.id)}
+            isDragging={isDragging}
             style={{
               left: `${point.x}%`,
               top: `${point.y}%`,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -277,7 +277,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       </motion.div>
 
       {/* Player ship - fixed position in center */}
-      <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 z-20">
+      <div
+        className={`absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 z-20 ${isDragging ? "pointer-events-none" : ""}`}
+      >
         <PlayerShip
           rotation={shipRotation}
           isNearPoint={nearbyPoint !== null}
@@ -291,7 +293,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 20 }}
-          className="absolute bottom-4 left-1/2 transform -translate-x-1/2 bg-black/80 text-white px-4 py-2 rounded-lg text-sm backdrop-blur-sm border border-green-400/30"
+          className={`absolute bottom-4 left-1/2 transform -translate-x-1/2 bg-black/80 text-white px-4 py-2 rounded-lg text-sm backdrop-blur-sm border border-green-400/30 ${isDragging ? "pointer-events-none" : ""}`}
         >
           <div className="text-green-400 font-medium">
             {GALAXY_POINTS.find((p) => p.id === nearbyPoint)?.name}
@@ -301,7 +303,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       )}
 
       {/* Navigation hint */}
-      <div className="absolute top-4 right-4 text-white/60 text-xs bg-black/40 px-3 py-2 rounded-lg backdrop-blur-sm">
+      <div
+        className={`absolute top-4 right-4 text-white/60 text-xs bg-black/40 px-3 py-2 rounded-lg backdrop-blur-sm ${isDragging ? "pointer-events-none" : ""}`}
+      >
         Arraste para navegar
       </div>
     </div>

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -16,6 +16,7 @@ interface MapPointProps {
   point: MapPointData;
   isNearby: boolean;
   onClick: () => void;
+  isDragging?: boolean;
   style?: React.CSSProperties;
 }
 
@@ -73,6 +74,7 @@ export const MapPoint: React.FC<MapPointProps> = ({
   point,
   isNearby,
   onClick,
+  isDragging = false,
   style,
 }) => {
   const Icon = getPointIcon(point.type);
@@ -80,11 +82,11 @@ export const MapPoint: React.FC<MapPointProps> = ({
 
   return (
     <motion.div
-      className="absolute cursor-pointer z-10"
+      className={`absolute z-10 ${isDragging ? "pointer-events-none" : "cursor-pointer"}`}
       style={style}
       onClick={onClick}
-      whileHover={{ scale: 1.2 }}
-      whileTap={{ scale: 0.9 }}
+      whileHover={!isDragging ? { scale: 1.2 } : {}}
+      whileTap={!isDragging ? { scale: 0.9 } : {}}
       initial={{ opacity: 0, scale: 0 }}
       animate={{
         opacity: 1,

--- a/src/components/World/PlayerShip.tsx
+++ b/src/components/World/PlayerShip.tsx
@@ -14,7 +14,7 @@ export const PlayerShip: React.FC<PlayerShipProps> = ({
 }) => {
   return (
     <motion.div
-      className={`relative w-8 h-8 z-20 ${isDragging ? "pointer-events-none" : ""}`}
+      className={`relative w-9 h-9 z-20 ${isDragging ? "pointer-events-none" : ""}`}
       style={{ rotate: rotation }}
       animate={{
         scale: isDragging ? 1.1 : 1,

--- a/src/components/World/PlayerShip.tsx
+++ b/src/components/World/PlayerShip.tsx
@@ -14,7 +14,7 @@ export const PlayerShip: React.FC<PlayerShipProps> = ({
 }) => {
   return (
     <motion.div
-      className="relative w-8 h-8 z-20"
+      className={`relative w-8 h-8 z-20 ${isDragging ? "pointer-events-none" : ""}`}
       style={{ rotate: rotation }}
       animate={{
         scale: isDragging ? 1.1 : 1,

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Galaxy map animations */
+@keyframes twinkle {
+  0% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 0.8;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0.4;
+    transform: scale(0.9);
+  }
+}


### PR DESCRIPTION
This change improves the user experience when dragging the galaxy map and reorganizes CSS animations.

Changes made:
- Added conditional cursor states (grab/grabbing) based on isDragging state
- Added userSelect: "none" style to prevent text selection during drag
- Added pointer-events-none to UI elements during dragging to prevent interference
- Passed isDragging prop to MapPoint component to disable hover/tap animations while dragging
- Disabled MapPoint hover and tap animations when isDragging is true
- Increased PlayerShip size from w-8 h-8 to w-9 h-9
- Added pointer-events-none to PlayerShip during dragging
- Moved twinkle animation CSS from inline style to global CSS file (index.css)
- Removed the inline style block for twinkle animation from GalaxyMap component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c16f711f9ac3455b9e08429523bf47d5/quantum-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c16f711f9ac3455b9e08429523bf47d5</projectId>-->
<!--<branchName>quantum-garden</branchName>-->