### PR TITLE
Adjust GalaxyMap drag constraints and boundary detection

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -284,13 +284,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
           style={{
             // Container real: 448px width × 500px height
             // Map: 896px width (448×2) × 1000px height (500×2)
-            // Constraints: ±400px both directions
-            // Vertical: 400px of 1000px = 40%, so 10% to 90% ✓
-            // Horizontal: 400px of 896px = 44.6%, so 5.4% to 94.6%
-            left: "5.4%", // 50% - 44.6% = 5.4%
-            top: "10%", // 50% - 40% = 10% ✓
-            width: "89.2%", // 44.6% × 2 = 89.2%
-            height: "80%", // 40% × 2 = 80% ✓
+            // Constraints: ±224px horizontal, ±250px vertical
+            // Horizontal: 224px of 896px = 25%, so 25% to 75%
+            // Vertical: 250px of 1000px = 25%, so 25% to 75%
+            left: "25%", // 50% - 25% = 25%
+            top: "25%", // 50% - 25% = 25%
+            width: "50%", // 25% × 2 = 50%
+            height: "50%", // 25% × 2 = 50%
           }}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -267,10 +267,10 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
         style={{ x: mapX, y: mapY }}
         drag
         dragConstraints={{
-          left: -400,
-          right: 400,
-          top: -400,
-          bottom: 400,
+          left: -224,
+          right: 224,
+          top: -250,
+          bottom: 250,
         }}
         dragElastic={0.1}
         onDragStart={handleDragStart}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -167,10 +167,10 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       const newX = mapX.get() + deltaX;
       const newY = mapY.get() + deltaY;
 
-      // Check boundary proximity
-      const boundaryThreshold = 20; // Distance from boundary to trigger warning
-      const isNearX = newX <= -204 || newX >= 204; // 224 - 20 = 204
-      const isNearY = newY <= -230 || newY >= 230; // 250 - 20 = 230
+      // Check boundary proximity - only trigger when very close to actual constraints
+      const boundaryThreshold = 5; // Very small threshold to be precise
+      const isNearX = newX <= -219 || newX >= 219; // 224 - 5 = 219
+      const isNearY = newY <= -245 || newY >= 245; // 250 - 5 = 245
       setIsNearBoundary(isNearX || isNearY);
 
       // Only calculate rotation if there's significant movement

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -282,15 +282,16 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
         <motion.div
           className="absolute pointer-events-none z-10"
           style={{
-            // Container real: 448px width × 500px height
-            // Map: 896px width (448×2) × 1000px height (500×2)
+            // Map: 200% width × 200% height (double the container)
             // Constraints: ±224px horizontal, ±250px vertical
-            // Horizontal: 224px of 896px = 25%, so 25% to 75%
-            // Vertical: 250px of 1000px = 25%, so 25% to 75%
-            left: "25%", // 50% - 25% = 25%
-            top: "25%", // 50% - 25% = 25%
-            width: "50%", // 25% × 2 = 50%
-            height: "50%", // 25% × 2 = 50%
+            // For a map that's 200% of container, movement range should be:
+            // Horizontal: 224px of (container_width) = constraint/container ratio
+            // Vertical: 250px of 500px = 50%, so 25% to 75%
+            // Adjusting horizontal to match actual container proportions
+            left: "12.5%", // More narrow horizontal bounds
+            top: "25%",
+            width: "75%", // Wider area for horizontal movement
+            height: "50%",
           }}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -168,9 +168,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       const newY = mapY.get() + deltaY;
 
       // Check boundary proximity
-      const boundaryThreshold = 50; // Distance from boundary to trigger warning
-      const isNearX = newX <= -174 || newX >= 174; // 224 - 50 = 174
-      const isNearY = newY <= -200 || newY >= 200; // 250 - 50 = 200
+      const boundaryThreshold = 20; // Distance from boundary to trigger warning
+      const isNearX = newX <= -204 || newX >= 204; // 224 - 20 = 204
+      const isNearY = newY <= -230 || newY >= 230; // 250 - 20 = 230
       setIsNearBoundary(isNearX || isNearY);
 
       // Only calculate rotation if there's significant movement

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -169,8 +169,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
 
       // Check boundary proximity
       const boundaryThreshold = 50; // Distance from boundary to trigger warning
-      const isNearX = newX <= -350 || newX >= 350;
-      const isNearY = newY <= -350 || newY >= 350;
+      const isNearX = newX <= -174 || newX >= 174; // 224 - 50 = 174
+      const isNearY = newY <= -200 || newY >= 200; // 250 - 50 = 200
       setIsNearBoundary(isNearX || isNearY);
 
       // Only calculate rotation if there's significant movement


### PR DESCRIPTION
Updates drag constraints and boundary detection in GalaxyMap component:

- Reduces drag constraints from ±400px to ±224px horizontal and ±250px vertical
- Adjusts boundary detection threshold from 50px to 5px for more precise triggering
- Updates boundary proximity checks to use new constraint values (219px and 245px)
- Modifies positioning styles: left from 5.4% to 12.5%, top from 10% to 25%
- Changes dimensions: width from 89.2% to 75%, height from 80% to 50%
- Updates comments to reflect new constraint calculations and proportions

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c615d6919e21497186b8850cf702bdf9/flare-landing)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c615d6919e21497186b8850cf702bdf9</projectId>-->
<!--<branchName>flare-landing</branchName>-->