### PR TITLE
Update GalaxyMap navigation ratio and container height

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -27,7 +27,7 @@ interface MapPointData {
 // All values calculated from this single configuration to prevent inconsistencies
 const NAVIGATION_CONFIG = {
   // Container size multiplier for navigation area (1.0 = container size, 0.8 = 80% of container)
-  navigationRatio: 0.8, // 80% of container size provides good navigation area with clear boundaries
+  navigationRatio: 4.8, // 80% of container size provides good navigation area with clear boundaries
   boundaryThreshold: 15, // pixels from boundary edge for proximity warning
   minContainerSize: 400, // minimum container size for calculations
   mapSizeMultiplier: 2.0, // map is 2x container size (200%)

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -456,7 +456,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   return (
     <div
       ref={containerRef}
-      className={`relative w-full h-[500px] bg-gradient-to-br from-gray-950 via-slate-900 to-black rounded-2xl overflow-hidden ${
+      className={`relative w-full h-[650px] bg-gradient-to-br from-gray-950 via-slate-900 to-black rounded-2xl overflow-hidden ${
         isDragging ? "cursor-grabbing" : "cursor-grab"
       }`}
       style={{ userSelect: "none" }}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -456,7 +456,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   return (
     <div
       ref={containerRef}
-      className={`relative w-full h-[750px] bg-gradient-to-br from-gray-950 via-slate-900 to-black rounded-2xl overflow-hidden ${
+      className={`relative w-full h-[500px] bg-gradient-to-br from-gray-950 via-slate-900 to-black rounded-2xl overflow-hidden ${
         isDragging ? "cursor-grabbing" : "cursor-grab"
       }`}
       style={{ userSelect: "none" }}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -91,8 +91,8 @@ const getUnifiedNavigationConfig = (
 const GALAXY_POINTS: MapPointData[] = [
   {
     id: "terra-nova",
-    x: 48,
-    y: 47,
+    x: 40,
+    y: 45,
     name: "Terra Nova",
     type: "planet",
     description: "Um planeta verdejante cheio de vida",
@@ -101,8 +101,8 @@ const GALAXY_POINTS: MapPointData[] = [
   },
   {
     id: "estacao-omega",
-    x: 52,
-    y: 48,
+    x: 60,
+    y: 35,
     name: "Estação Omega",
     type: "station",
     description: "Centro comercial da galáxia",
@@ -110,8 +110,8 @@ const GALAXY_POINTS: MapPointData[] = [
   },
   {
     id: "nebulosa-crimson",
-    x: 49,
-    y: 52,
+    x: 30,
+    y: 65,
     name: "Nebulosa Crimson",
     type: "nebula",
     description: "Uma nebulosa misteriosa com energia estranha",
@@ -119,8 +119,8 @@ const GALAXY_POINTS: MapPointData[] = [
   },
   {
     id: "campo-asteroides",
-    x: 51,
-    y: 53,
+    x: 70,
+    y: 55,
     name: "Campo de Asteroides",
     type: "asteroid",
     description: "Rico em recursos minerais raros",
@@ -129,7 +129,7 @@ const GALAXY_POINTS: MapPointData[] = [
   {
     id: "mundo-gelado",
     x: 50,
-    y: 49,
+    y: 25,
     name: "Mundo Gelado",
     type: "planet",
     description: "Planeta coberto de gelo eterno",

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -27,7 +27,7 @@ interface MapPointData {
 // All values calculated from this single configuration to prevent inconsistencies
 const NAVIGATION_CONFIG = {
   // Container size multiplier for navigation area (1.0 = container size, 0.8 = 80% of container)
-  navigationRatio: 5.6, // 80% of container size provides good navigation area with clear boundaries
+  navigationRatio: 0.8, // 80% of container size provides good navigation area with clear boundaries
   boundaryThreshold: 15, // pixels from boundary edge for proximity warning
   minContainerSize: 400, // minimum container size for calculations
   mapSizeMultiplier: 2.0, // map is 2x container size (200%)

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -91,8 +91,8 @@ const getUnifiedNavigationConfig = (
 const GALAXY_POINTS: MapPointData[] = [
   {
     id: "terra-nova",
-    x: 40,
-    y: 45,
+    x: 48,
+    y: 47,
     name: "Terra Nova",
     type: "planet",
     description: "Um planeta verdejante cheio de vida",
@@ -101,8 +101,8 @@ const GALAXY_POINTS: MapPointData[] = [
   },
   {
     id: "estacao-omega",
-    x: 60,
-    y: 35,
+    x: 52,
+    y: 48,
     name: "Estação Omega",
     type: "station",
     description: "Centro comercial da galáxia",
@@ -110,8 +110,8 @@ const GALAXY_POINTS: MapPointData[] = [
   },
   {
     id: "nebulosa-crimson",
-    x: 30,
-    y: 65,
+    x: 49,
+    y: 52,
     name: "Nebulosa Crimson",
     type: "nebula",
     description: "Uma nebulosa misteriosa com energia estranha",
@@ -119,8 +119,8 @@ const GALAXY_POINTS: MapPointData[] = [
   },
   {
     id: "campo-asteroides",
-    x: 70,
-    y: 55,
+    x: 51,
+    y: 53,
     name: "Campo de Asteroides",
     type: "asteroid",
     description: "Rico em recursos minerais raros",
@@ -129,7 +129,7 @@ const GALAXY_POINTS: MapPointData[] = [
   {
     id: "mundo-gelado",
     x: 50,
-    y: 25,
+    y: 49,
     name: "Mundo Gelado",
     type: "planet",
     description: "Planeta coberto de gelo eterno",

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -27,7 +27,7 @@ interface MapPointData {
 // All values calculated from this single configuration to prevent inconsistencies
 const NAVIGATION_CONFIG = {
   // Container size multiplier for navigation area (1.0 = container size, 0.8 = 80% of container)
-  navigationRatio: 0.8, // 80% of container size provides good navigation area with clear boundaries
+  navigationRatio: 5.6, // 80% of container size provides good navigation area with clear boundaries
   boundaryThreshold: 15, // pixels from boundary edge for proximity warning
   minContainerSize: 400, // minimum container size for calculations
   mapSizeMultiplier: 2.0, // map is 2x container size (200%)


### PR DESCRIPTION
Updates two configuration values in the GalaxyMap component:

- Increases navigationRatio from 0.8 to 4.8 in NAVIGATION_CONFIG
- Reduces container height from 750px to 650px in the main div className

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2a834b407c2a4240ad8469242c0c26b5/stellar-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2a834b407c2a4240ad8469242c0c26b5</projectId>-->
<!--<branchName>stellar-hub</branchName>-->